### PR TITLE
Added value to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This a list of props that you can pass down to the component:
 | -------- | ----------- | ------------- | ---- |
 | `className`  | Name of parent class | `null` | string |
 | `count`  | How many total stars you want  | 5 | number |
+| `value`  | Set rating value  | 0 | number |
 | `char` | Which character you want to use as a star | ★ | string |
 | `color1` | Color of inactive star (this supports any CSS valid value) | `gray` | string |
 | `color2` | Color of selected or active star | `#ffd700` | string |


### PR DESCRIPTION
There may be a case where one should want to use this widget to display a read-only value. In this case one should set `edit` to `false` and `value` (which **can** be set as a state from the parent) to the preferred value.