### PR TITLE
Fixing receiving props "edit" and "half"

### DIFF
--- a/dist/react-stars.js
+++ b/dist/react-stars.js
@@ -49,17 +49,9 @@ var ReactStars = function (_Component) {
 
     props = _extends({}, props);
 
-    if (typeof props.edit === 'undefined') {
-      props.edit = true;
-    } else {
-      props.edit = false;
-    }
+    if (typeof props.edit === 'undefined') props.edit = true;
 
-    if (typeof props.half === 'undefined') {
-      props.half = true;
-    } else {
-      props.half = false;
-    }
+    if (typeof props.half === 'undefined') props.half = true;
 
     _this.state = {
       uniqueness: (Math.random() + '').replace('.', ''),

--- a/src/react-stars.js
+++ b/src/react-stars.js
@@ -37,17 +37,11 @@ class ReactStars extends Component {
 
     props = Object.assign({}, props)
 
-    if(typeof props.edit === 'undefined') {
+    if (typeof props.edit === 'undefined')
       props.edit = true
-    } else {
-      props.edit = false
-    }
 
-    if(typeof props.half === 'undefined') {
+    if (typeof props.half === 'undefined')
       props.half = true
-    } else {
-      props.half = false
-    }
 
     this.state = {
       uniqueness: (Math.random() + '').replace('.', ''),


### PR DESCRIPTION
There is a bug: when you set "edit" or "half" props to any value (true or false), the component interprets it as "false". There is a fix.