### PR TITLE
Update props table in readme to say size should be a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This a list of props that you can pass down to the component:
 | `char` | Which character you want to use as a star | ★ | string |
 | `color1` | Color of inactive star (this supports any CSS valid value) | `gray` | string |
 | `color2` | Color of selected or active star | `#ffd700` | string |
-| `size` | Size of stars (in px) | `15px` | string |
+| `size` | Size of stars (in px) | `15px` | number |
 | `edit` | Should you be able to select rating or just see rating (for reusability) | `true` | boolean |
 | `half` | Should component use half stars, if not the decimal part will be dropped otherwise normal algebra rools will apply to round to half stars | `true` | boolean
 | `onChange(new_rating)` | Will be invoked any time the rating is changed | `null` | function |


### PR DESCRIPTION
The prop-types say that the size prop should be a number, and the example code in the readme also uses a number, so the table should also say number, not string.